### PR TITLE
Adding shape and contour defmethod

### DIFF
--- a/src/play_cljs/sketch.cljs
+++ b/src/play_cljs/sketch.cljs
@@ -252,6 +252,21 @@
     (.draw value x y)
     (draw-sketch! renderer children opts)))
 
+(defmethod draw-sketch! :shape [renderer content parent-opts]
+           (let [[command opts & children] content
+                 opts (update-opts opts parent-opts basic-defaults)
+                 {:keys [points] :as opts} opts]
+                (cond (odd? (count points))
+                      (throw ":shape requires :points to contain a collection with an even number of values (x and y pairs)")
+                      :else
+                      (do (.beginShape renderer)
+                          (loop [[x y & rest] points]
+                                (.vertex renderer x y)
+                                (when rest
+                                      (recur rest)))
+                          (.endShape renderer (.-CLOSE renderer))))
+                (draw-sketch! renderer children opts)))
+
 (defmethod draw-sketch! :default [renderer content parent-opts]
   (cond
     (sequential? (first content))

--- a/src/play_cljs/sketch.cljs
+++ b/src/play_cljs/sketch.cljs
@@ -257,15 +257,32 @@
                  opts (update-opts opts parent-opts basic-defaults)
                  {:keys [points] :as opts} opts]
                 (cond (odd? (count points))
-                      (throw ":shape requires :points to contain a collection with an even number of values (x and y pairs)")
+                      (throw ":shape requires :points to contain a seq'able with an even number of values (x and y pairs)")
                       :else
                       (do (.beginShape renderer)
                           (loop [[x y & rest] points]
                                 (.vertex renderer x y)
                                 (when rest
                                       (recur rest)))
-                          (.endShape renderer (.-CLOSE renderer))))
-                (draw-sketch! renderer children opts)))
+                          (draw-sketch! renderer children opts)
+                          (.endShape renderer (.-CLOSE renderer))))))
+
+
+(defmethod draw-sketch! :contour [renderer content parent-opts]
+           (let [[command opts & children] content
+                 opts (update-opts opts parent-opts basic-defaults)
+                 {:keys [points] :as opts} opts]
+                (cond (odd? (count points))
+                      (throw ":contour requires :points to contain a seq'able with an even number of values (x and y pairs)")
+                      :else
+                      (do (.beginContour renderer)
+                          (loop [[x y & rest] points]
+                                (.vertex renderer x y)
+                                (when rest
+                                      (recur rest)))
+                          (draw-sketch! renderer children opts)
+                          (.endContour renderer (.-CLOSE renderer))))))
+
 
 (defmethod draw-sketch! :default [renderer content parent-opts]
   (cond

--- a/src/play_cljs/sketch.cljs
+++ b/src/play_cljs/sketch.cljs
@@ -252,10 +252,11 @@
     (.draw value x y)
     (draw-sketch! renderer children opts)))
 
+
 (defmethod draw-sketch! :shape [renderer content parent-opts]
            (let [[command opts & children] content
                  opts (update-opts opts parent-opts basic-defaults)
-                 {:keys [points] :as opts} opts]
+                 points (:points opts)]
                 (cond (odd? (count points))
                       (throw ":shape requires :points to contain a seq'able with an even number of values (x and y pairs)")
                       :else
@@ -271,7 +272,7 @@
 (defmethod draw-sketch! :contour [renderer content parent-opts]
            (let [[command opts & children] content
                  opts (update-opts opts parent-opts basic-defaults)
-                 {:keys [points] :as opts} opts]
+                 points (:points opts)]
                 (cond (odd? (count points))
                       (throw ":contour requires :points to contain a seq'able with an even number of values (x and y pairs)")
                       :else
@@ -282,6 +283,7 @@
                                       (recur rest)))
                           (draw-sketch! renderer children opts)
                           (.endContour renderer (.-CLOSE renderer))))))
+
 
 
 (defmethod draw-sketch! :default [renderer content parent-opts]


### PR DESCRIPTION
example of using shape:

 to draw a square
[:shape {:points [ 30 20 85 20 85 75 30 75] } ]

 to draw a hex
[:shape {:points [135 121.2435565298214 120 147.22431864335456 90 147.22431864335456 75 121.2435565298214 89.99999999999999 95.26279441628824 120 95.26279441628824] } ]

example of using contour (per p5.js it must be used only within a shape)

square with the center hallowed out (from the p5 reference page)
                                   [:shape {:points [ -40 -40 40 -40 40 40 -40 40] }
                                    [:contour {:points [-20 -20 -20 20 20 20 20 -20]}]]


