### PR TITLE
Feat/image flip

### DIFF
--- a/src/play_cljs/core.cljs
+++ b/src/play_cljs/core.cljs
@@ -41,8 +41,8 @@ should create just one such object by calling [create-game](#create-game)."
   (load-image [game path]
     "Loads an image. Returns an [Image](#Image) object.")
   (load-tiled-map [game map-name]
-    "Loads a tiled map. Returns a [TiledMap](#TiledMap) object. 
-A tiled map with the provided name must already be loaded 
+    "Loads a tiled map. Returns a [TiledMap](#TiledMap) object.
+A tiled map with the provided name must already be loaded
 (see the TiledMap docs for details).")
   (get-screen [game]
     "Returns the [Screen](#Screen) object currently being displayed.")
@@ -192,11 +192,13 @@ A tiled map with the provided name must already be loaded
                                (load-image game name))
         swidth (or swidth (.-width value))
         sheight (or sheight (.-height value))]
+    (.push renderer)
     (.scale renderer scale-x scale-y)
     (.image renderer value
       x y (or width swidth) (or height sheight)
       sx sy swidth sheight)
-    (draw-sketch! game renderer children opts)))
+    (draw-sketch! game renderer children opts)
+    (.pop renderer)))
 
 (defmethod draw-sketch! :animation [game ^js/p5 renderer content parent-opts]
   (let [[command opts & children] content
@@ -475,4 +477,3 @@ A tiled map with the provided name must already be loaded
         (.resizeCanvas renderer width height))
       (get-asset [game name]
         (get-in @hidden-state-atom [:assets name])))))
-

--- a/src/play_cljs/core.cljs
+++ b/src/play_cljs/core.cljs
@@ -185,18 +185,25 @@ A tiled map with the provided name must already be loaded
 
 (defmethod draw-sketch! :image [game ^js/p5 renderer content parent-opts]
   (let [[command opts & children] content
-        {:keys [value name x y width height sx sy swidth sheight scale-x scale-y] :as opts}
-        (update-opts opts parent-opts img-defaults)
+        {:keys [value name x y width height sx sy swidth sheight scale-x scale-y flip-x flip-y]
+         :as opts} (update-opts opts parent-opts img-defaults)
         ^js/p5.Image value (or value
                                (get-asset game name)
                                (load-image game name))
         swidth (or swidth (.-width value))
         sheight (or sheight (.-height value))]
     (.push renderer)
+    (.translate renderer sx sy)
     (.scale renderer scale-x scale-y)
+    (when flip-x
+      (.scale renderer -1 1)
+      (.translate renderer (- swidth) 0))
+    (when flip-y
+      (.scale renderer 1 -1)
+      (.translate renderer 0 (- sheight)))
     (.image renderer value
       x y (or width swidth) (or height sheight)
-      sx sy swidth sheight)
+      0 0 swidth sheight)
     (draw-sketch! game renderer children opts)
     (.pop renderer)))
 


### PR DESCRIPTION
When you're rendering images, sometimes it's useful to flip them on their x or y axes. This PR implements that feature.

```Clojure
(p/render [[:image [:name "mario.png" :sx 10 :sy 20 :flip-x true :flip-y false :scale 10]])
```

Suppose that `mario.png` contains Mario walking left. The above will render Mario at coordinates `(10, 20)` walking right, 10 times larger (on the canvas than on the image he's being rendered from). 

### Demo
http://imgur.com/a/aV6eK

### Minor notes
This PR build on top of PR https://github.com/oakes/play-cljs/pull/5.